### PR TITLE
Updated a deprecated method with the new one in `test/getstorage_test.dart`

### DIFF
--- a/test/getstorage_test.dart
+++ b/test/getstorage_test.dart
@@ -15,11 +15,14 @@ void main() async {
 
   const channel = MethodChannel('plugins.flutter.io/path_provider');
   void setUpMockChannels(MethodChannel channel) {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      if (methodCall.method == 'getApplicationDocumentsDirectory') {
-        return '.';
-      }
-    });
+    TestDefaultBinaryMessengerBinding.instance?.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      (MethodCall? methodCall) async {
+        if (methodCall?.method == 'getApplicationDocumentsDirectory') {
+          return '.';
+        }
+      },
+    );
   }
 
   setUpAll(() async {
@@ -118,8 +121,7 @@ void main() async {
   });
 
   group('get keys/values', () {
-    Function(Iterable, List) eq =
-        (i, l) => const ListEquality().equals(i.toList(), l);
+    Function(Iterable, List) eq = (i, l) => const ListEquality().equals(i.toList(), l);
 
     test('should return their stored dynamic values', () {
       expect(eq(g.getKeys().toList(), []), true);
@@ -140,11 +142,9 @@ void main() async {
   });
 }
 
-Future<File> _fileDb(
-    {bool isBackup = false, String fileName = 'GetStorage'}) async {
+Future<File> _fileDb({bool isBackup = false, String fileName = 'GetStorage'}) async {
   final dir = await getApplicationDocumentsDirectory();
   final _path = dir.path;
-  final _file =
-      isBackup ? File('$_path/$fileName.bak') : File('$_path/$fileName.gs');
+  final _file = isBackup ? File('$_path/$fileName.bak') : File('$_path/$fileName.gs');
   return _file;
 }


### PR DESCRIPTION
With this PR, I simply changed this file:
`test/getstorage_test.dart`

There was a method used for injecting a mock channel:
`channel.setMockMethodCallHandler`

It is deprecated so I have made the appropriate changes using up to date method (Flutter version: 2.5.1):
`TestDefaultBinaryMessengerBinding`

The error message before this fix:
`package:flutter_test/src/deprecated.dart 95:47 TestMethodChannelExtension.setMockMethodCallHandler`